### PR TITLE
Add shared Bootstrap layout and entity templates

### DIFF
--- a/src/main/resources/templates/categories.html
+++ b/src/main/resources/templates/categories.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: layout(~{::title}, ~{::section})}">
+<head>
+    <title>Categories</title>
+</head>
+<body>
+<section>
+    <h1>Categories</h1>
+    <p>Manage categories here.</p>
+</section>
+</body>
+</html>

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:fragment="layout (pageTitle, content)">
+<head>
+    <meta charset="UTF-8">
+    <title th:replace="${pageTitle}">Demo</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
+          integrity="sha384-QWTKZyjpPEjISv5WaRUy14kQfZLkfcZ2lvqHbVZl5nFfZCS6hLRV8aonbN3c47Nb" crossorigin="anonymous">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light">
+  <div class="container-fluid">
+    <a class="navbar-brand" th:href="@{/}">Demo</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav">
+        <li class="nav-item"><a class="nav-link" th:href="@{/products}">Products</a></li>
+        <li class="nav-item"><a class="nav-link" th:href="@{/categories}">Categories</a></li>
+        <li class="nav-item"><a class="nav-link" th:href="@{/orders}">Orders</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
+
+<div class="container mt-4">
+  <div class="row">
+    <div class="col-12" th:replace="${content}"></div>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-ENjdO4Dr2bkBIFxQpeoY9F0ZrIqK7auYJp7B4oNfO8N6eDQnH3U2lg5z6caXp6k4" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/src/main/resources/templates/orders.html
+++ b/src/main/resources/templates/orders.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: layout(~{::title}, ~{::section})}">
+<head>
+    <title>Orders</title>
+</head>
+<body>
+<section>
+    <h1>Orders</h1>
+    <p>Manage orders here.</p>
+</section>
+</body>
+</html>

--- a/src/main/resources/templates/products.html
+++ b/src/main/resources/templates/products.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: layout(~{::title}, ~{::section})}">
+<head>
+    <title>Products</title>
+</head>
+<body>
+<section>
+    <h1>Products</h1>
+    <p>Manage products here.</p>
+</section>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Introduce a Bootstrap-based `layout.html` with shared navbar and grid structure
- Create `products.html`, `categories.html`, and `orders.html` templates that extend the new layout

## Testing
- `mvn -q test` *(fails: Could not transfer artifact spring-boot-starter-parent: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f345bb294832085bcc79852e9e4e2