### PR TITLE
Add category management views and templates

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,24 @@
+from flask import Flask
+
+from db import db
+from views.categories import bp as categories_bp
+from views.products import bp as products_bp
+
+
+def create_app():
+    app = Flask(__name__)
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///app.db'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.secret_key = 'dev'
+    db.init_app(app)
+
+    app.register_blueprint(categories_bp)
+    app.register_blueprint(products_bp)
+
+    return app
+
+
+app = create_app()
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -1,0 +1,6 @@
+from flask_sqlalchemy import SQLAlchemy
+
+db = SQLAlchemy()
+
+# Import models to register them with SQLAlchemy metadata
+from models.category import Category  # noqa: F401

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,2 @@
+# models package
+from .category import Category

--- a/models/category.py
+++ b/models/category.py
@@ -1,0 +1,9 @@
+from db import db
+
+class Category(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(80), unique=True, nullable=False)
+    description = db.Column(db.Text)
+
+    def __repr__(self):
+        return f"<Category {self.name}>"

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <title>{% block title %}App{% endblock %}</title>
+  </head>
+  <body>
+    {% with messages = get_flashed_messages() %}
+      {% if messages %}
+        <div class="container mt-3">
+          {% for message in messages %}
+            <div class="alert alert-info">{{ message }}</div>
+          {% endfor %}
+        </div>
+      {% endif %}
+    {% endwith %}
+    {% block content %}{% endblock %}
+  </body>
+</html>

--- a/templates/categories/form.html
+++ b/templates/categories/form.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container mt-4">
+  <h1>{{ 'Edit' if category else 'New' }} Category</h1>
+  <form method="post">
+    <div class="mb-3">
+      <label for="name" class="form-label">Name</label>
+      <input type="text" class="form-control" name="name" id="name" value="{{ category.name if category else '' }}" required>
+    </div>
+    <div class="mb-3">
+      <label for="description" class="form-label">Description</label>
+      <textarea class="form-control" name="description" id="description">{{ category.description if category else '' }}</textarea>
+    </div>
+    <button type="submit" class="btn btn-primary">Save</button>
+  </form>
+</div>
+{% endblock %}

--- a/templates/categories/index.html
+++ b/templates/categories/index.html
@@ -1,0 +1,26 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container mt-4">
+  <h1>Categories</h1>
+  <a class="btn btn-primary" href="{{ url_for('categories.create') }}">New Category</a>
+  <table class="table table-striped mt-3">
+    <thead>
+      <tr><th>Name</th><th>Description</th><th></th></tr>
+    </thead>
+    <tbody>
+    {% for category in categories %}
+      <tr>
+        <td>{{ category.name }}</td>
+        <td>{{ category.description }}</td>
+        <td>
+          <a class="btn btn-sm btn-secondary" href="{{ url_for('categories.edit', id=category.id) }}">Edit</a>
+          <form action="{{ url_for('categories.delete', id=category.id) }}" method="post" style="display:inline">
+            <button class="btn btn-sm btn-danger" type="submit">Delete</button>
+          </form>
+        </td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/templates/products/form.html
+++ b/templates/products/form.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container mt-4">
+  <h1>New Product</h1>
+  <form method="post">
+    <div class="mb-3">
+      <label for="name" class="form-label">Name</label>
+      <input type="text" class="form-control" name="name" id="name">
+    </div>
+    <div class="mb-3">
+      <label for="category_id" class="form-label">Category</label>
+      <select class="form-select" name="category_id" id="category_id">
+        {% for c in categories %}
+        <option value="{{ c.id }}">{{ c.name }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <button type="submit" class="btn btn-primary">Save</button>
+  </form>
+</div>
+{% endblock %}

--- a/views/categories.py
+++ b/views/categories.py
@@ -1,0 +1,42 @@
+from flask import Blueprint, render_template, request, redirect, url_for, flash
+
+from db import db
+from models.category import Category
+
+bp = Blueprint('categories', __name__, url_prefix='/categories')
+
+@bp.route('/')
+def index():
+    categories = Category.query.all()
+    return render_template('categories/index.html', categories=categories)
+
+@bp.route('/create', methods=['GET', 'POST'])
+def create():
+    if request.method == 'POST':
+        name = request.form['name']
+        description = request.form.get('description')
+        category = Category(name=name, description=description)
+        db.session.add(category)
+        db.session.commit()
+        flash('Category created')
+        return redirect(url_for('categories.index'))
+    return render_template('categories/form.html')
+
+@bp.route('/<int:id>/edit', methods=['GET', 'POST'])
+def edit(id):
+    category = Category.query.get_or_404(id)
+    if request.method == 'POST':
+        category.name = request.form['name']
+        category.description = request.form.get('description')
+        db.session.commit()
+        flash('Category updated')
+        return redirect(url_for('categories.index'))
+    return render_template('categories/form.html', category=category)
+
+@bp.route('/<int:id>/delete', methods=['POST'])
+def delete(id):
+    category = Category.query.get_or_404(id)
+    db.session.delete(category)
+    db.session.commit()
+    flash('Category deleted')
+    return redirect(url_for('categories.index'))

--- a/views/products.py
+++ b/views/products.py
@@ -1,0 +1,10 @@
+from flask import Blueprint, render_template
+
+from models.category import Category
+
+bp = Blueprint('products', __name__, url_prefix='/products')
+
+@bp.route('/create')
+def create():
+    categories = Category.query.all()
+    return render_template('products/form.html', categories=categories)


### PR DESCRIPTION
## Summary
- define SQLAlchemy Category model
- register Category and blueprints for categories and products
- add Bootstrap templates for category listing and forms
- include category dropdown in product form

## Testing
- `pytest`
- `python -c 'from app import db, app; app.app_context().push(); db.create_all()'` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_689f344f5bb0832096b2b91dc1ad254e