### PR TITLE
Add product CRUD with database and templates

### DIFF
--- a/db/__init__.py
+++ b/db/__init__.py
@@ -1,0 +1,24 @@
+"""Database setup and initialization."""
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+DATABASE_URL = "sqlite:///app.db"
+
+# SQLAlchemy base and session setup
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(bind=engine)
+Base = declarative_base()
+
+
+def init_db() -> None:
+    """Import all models and create tables."""
+    from models.product import Product  # noqa: F401
+
+    Base.metadata.create_all(bind=engine)
+
+
+# Run migrations automatically on import
+init_db()

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,1 @@
+# Models package

--- a/models/product.py
+++ b/models/product.py
@@ -1,0 +1,11 @@
+from sqlalchemy import Column, Integer, String, Float
+from db import Base
+
+
+class Product(Base):
+    __tablename__ = 'products'
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String(255), nullable=False)
+    price = Column(Float, nullable=False, default=0.0)
+    category_id = Column(Integer, nullable=True)

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>{% block title %}Demo{% endblock %}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-light bg-light">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="/">Demo</a>
+        <div class="collapse navbar-collapse">
+          <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+            <li class="nav-item"><a class="nav-link" href="/">Home</a></li>
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('products.list') }}">Products</a></li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+    <div class="container mt-4">
+      {% block content %}{% endblock %}
+    </div>
+  </body>
+</html>

--- a/templates/products/create.html
+++ b/templates/products/create.html
@@ -1,0 +1,20 @@
+{% extends 'layout.html' %}
+{% block title %}Create Product{% endblock %}
+{% block content %}
+<h1>Create Product</h1>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Name</label>
+    <input name="name" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Price</label>
+    <input name="price" type="number" step="0.01" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Category ID</label>
+    <input name="category_id" type="number" class="form-control">
+  </div>
+  <button type="submit" class="btn btn-primary">Save</button>
+</form>
+{% endblock %}

--- a/templates/products/edit.html
+++ b/templates/products/edit.html
@@ -1,0 +1,20 @@
+{% extends 'layout.html' %}
+{% block title %}Edit Product{% endblock %}
+{% block content %}
+<h1>Edit Product</h1>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Name</label>
+    <input name="name" value="{{ product.name }}" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Price</label>
+    <input name="price" type="number" step="0.01" value="{{ product.price }}" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Category ID</label>
+    <input name="category_id" type="number" value="{{ product.category_id }}" class="form-control">
+  </div>
+  <button type="submit" class="btn btn-primary">Update</button>
+</form>
+{% endblock %}

--- a/templates/products/list.html
+++ b/templates/products/list.html
@@ -1,0 +1,33 @@
+{% extends 'layout.html' %}
+{% block title %}Products{% endblock %}
+{% block content %}
+<h1>Products</h1>
+<a href="{{ url_for('products.create') }}" class="btn btn-primary mb-3">Create Product</a>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Name</th>
+      <th>Price</th>
+      <th>Category ID</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for product in products %}
+    <tr>
+      <td>{{ product.id }}</td>
+      <td>{{ product.name }}</td>
+      <td>{{ '%.2f'|format(product.price) }}</td>
+      <td>{{ product.category_id }}</td>
+      <td>
+        <a href="{{ url_for('products.edit', product_id=product.id) }}" class="btn btn-sm btn-secondary">Edit</a>
+        <form action="{{ url_for('products.delete', product_id=product.id) }}" method="post" style="display:inline-block">
+          <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -1,0 +1,10 @@
+"""Application views."""
+
+from flask import Flask
+
+from .products import bp as products_bp
+
+
+def register(app: Flask) -> None:
+    """Register blueprints with the Flask app."""
+    app.register_blueprint(products_bp)

--- a/views/products.py
+++ b/views/products.py
@@ -1,0 +1,65 @@
+"""Product CRUD views."""
+
+from flask import Blueprint, redirect, render_template, request, url_for
+from sqlalchemy.orm import Session
+
+from db import SessionLocal
+from models.product import Product
+
+bp = Blueprint("products", __name__, url_prefix="/products")
+
+
+@bp.route("/")
+def list():
+    """List all products."""
+    session: Session = SessionLocal()
+    products = session.query(Product).all()
+    session.close()
+    return render_template("products/list.html", products=products)
+
+
+@bp.route("/create", methods=["GET", "POST"])
+def create():
+    """Create a new product."""
+    session: Session = SessionLocal()
+    if request.method == "POST":
+        product = Product(
+            name=request.form["name"],
+            price=float(request.form["price"] or 0),
+            category_id=int(request.form.get("category_id") or 0),
+        )
+        session.add(product)
+        session.commit()
+        session.close()
+        return redirect(url_for("products.list"))
+    session.close()
+    return render_template("products/create.html")
+
+
+@bp.route("/<int:product_id>/edit", methods=["GET", "POST"])
+def edit(product_id: int):
+    """Edit an existing product."""
+    session: Session = SessionLocal()
+    product = session.get(Product, product_id)
+    if request.method == "POST":
+        product.name = request.form["name"]
+        product.price = float(request.form["price"] or 0)
+        product.category_id = int(request.form.get("category_id") or 0)
+        session.commit()
+        session.close()
+        return redirect(url_for("products.list"))
+    session.expunge(product)
+    session.close()
+    return render_template("products/edit.html", product=product)
+
+
+@bp.route("/<int:product_id>/delete", methods=["POST"])
+def delete(product_id: int):
+    """Delete a product."""
+    session: Session = SessionLocal()
+    product = session.get(Product, product_id)
+    if product:
+        session.delete(product)
+        session.commit()
+    session.close()
+    return redirect(url_for("products.list"))


### PR DESCRIPTION
## Summary
- define `Product` model and database initialization
- add product CRUD views and routes
- build Bootstrap templates and navigation link for products

## Testing
- `python -m py_compile $(find . -name '*.py')`
- `pytest`
- `python - <<'PY'
from db import init_db
init_db()
print('migrated')
PY` *(fails: ModuleNotFoundError: No module named 'sqlalchemy' and installing packages via pip failed due to 403)*


------
https://chatgpt.com/codex/tasks/task_e_689f3449ce3c8320bf6b7d7cfd48bb4b